### PR TITLE
feat: [CI-18377]: Mask GCLOUD_ACCESS_TOKEN output env exported by the plugin

### DIFF
--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}secure{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-amd64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-windows-amd64
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-amd64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-arm64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-windows-amd64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-amd64
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}secure{{/if}}
+image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-amd64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-arm64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-windows-amd64
+    image: plugins/gcp-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-windows-amd64
     platform:
       architecture: amd64
       os: windows

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -99,7 +99,7 @@ func VerifyEnv(args Args) error {
 }
 
 func WriteEnvToFile(key, value string) error {
-	outputFile, err := os.OpenFile(os.Getenv("DRONE_OUTPUT"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	outputFile, err := os.OpenFile(os.Getenv("HARNESS_OUTPUT_SECRET_FILE"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open output file: %w", err)
 	}


### PR DESCRIPTION
This PR add a small change to mask the GCLOUD_ACCESS_TOKEN output env (by putting it in HARNESS_OUTPUT_SECRET_FILE instead of DRONE_OUTPUT) exported by the plugin can be seen as plain text under Pipeline_Plugin_step_output like below:
<img width="1255" height="510" alt="Screenshot 2025-07-21 at 12 13 21 PM" src="https://github.com/user-attachments/assets/b96a9a1e-35d4-416a-842a-783c0b206333" />

Testing: after the change it'll be seen like below:
<img width="1168" height="294" alt="Screenshot 2025-07-21 at 12 15 02 PM" src="https://github.com/user-attachments/assets/d9483f8a-a794-4fa4-8b1b-0a23e1b085a9" />
